### PR TITLE
Remove vaapi ext from manifest

### DIFF
--- a/net.baseart.Glide.yaml
+++ b/net.baseart.Glide.yaml
@@ -4,7 +4,6 @@ runtime-version: '3.38'
 sdk: org.gnome.Sdk
 sdk-extensions:
 - org.freedesktop.Sdk.Extension.rust-stable
-- org.freedesktop.Platform.VAAPI.Intel
 command: glide
 finish-args:
 - --device=dri


### PR DESCRIPTION
This isn't an sdk extension and it's automatically installed on systems with intel hardware so there is no use for it in manifest.