### PR TITLE
Update to GStreamer 1.18 and include ffmpeg

### DIFF
--- a/net.baseart.Glide.yaml
+++ b/net.baseart.Glide.yaml
@@ -9,7 +9,8 @@ cleanup:
 command: glide
 finish-args:
 - --device=dri
-- --filesystem=home
+- --filesystem=xdg-download
+- --filesystem=xdg-videos
 - --metadata=X-DConf=migrate-path=/net/baseart/Glide/
 - --share=ipc
 - --share=network

--- a/net.baseart.Glide.yaml
+++ b/net.baseart.Glide.yaml
@@ -4,6 +4,8 @@ runtime-version: '3.38'
 sdk: org.gnome.Sdk
 sdk-extensions:
 - org.freedesktop.Sdk.Extension.rust-stable
+cleanup:
+- /include
 command: glide
 finish-args:
 - --device=dri
@@ -21,25 +23,208 @@ build-options:
   env:
     CARGO_HOME: /run/build/glide/cargo
 modules:
-- name: gst-libav
+- name: gstreamer
+  buildsystem: meson
   builddir: true
   sources:
   - type: archive
-    url: https://gstreamer.freedesktop.org/src/gst-libav/gst-libav-1.16.2.tar.xz
-    sha256: c724f612700c15a933c7356fbeabb0bb9571fb5538f8b1b54d4d2d94188deef2
+    url: https://gstreamer.freedesktop.org/src/gstreamer/gstreamer-1.18.1.tar.xz
+    sha256: 79df8de21f284a105a5c1568527f8c559c583c85c0f2bd7bdb5b0372b8beecba
   config-opts:
-  - --disable-gtkdoc
-  - --with-system-libav=no
+    - -Dexamples=disabled
+    - -Dbenchmarks=disabled
+    - -Dlibunwind=enabled
+    - -Dlibdw=enabled
+    - -Ddbghelp=disabled
+    - -Dbash-completion=disabled
+    - -Dgtk_doc=disabled
+    - -Ddoc=disabled
+
+- name: gst-plugins-base
+  buildsystem: meson
+  builddir: true
+  sources:
+  - type: archive
+    url: https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-1.18.1.tar.xz
+    sha256: 1ba654d7de30f7284b4c7071b32f881b609733ce02ab6d9d9ea29386a036c641
+  config-opts:
+    - -Dwrap_mode=nofallback
+    - -Dcdparanoia=disabled
+    - -Dtremor=disabled
+    - -Dexamples=disabled
+    - -Dgtk_doc=disabled
+    - -Ddoc=disabled
+    - -Dtests=disabled
+
+- name: gst-plugins-good
+  buildsystem: meson
+  builddir: true
+  sources:
+  - type: archive
+    url: https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-good-1.18.1.tar.xz
+    sha256: e210e91a5590ecb6accc9d06c949a58ca6897d8edb3b3d55828e424c624f626c
+  config-opts:
+    - -Daalib=disabled
+    - -Ddoc=disabled
+    - -Dlibcaca=disabled
+    - -Ddv=disabled
+    - -Ddv1394=disabled
+    - -Drpicamsrc=disabled
+    - -Dshout2=disabled
+    - -Dtwolame=disabled
+    - -Dv4l2-gudev=disabled
+
+- name: gst-plugins-bad
+  buildsystem: meson
+  builddir: true
+  sources:
+  - type: archive
+    url: https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-1.18.1.tar.xz
+    sha256: c195978c85d97406c05eb9d43ac54b9ab35eda6ffdae32b3ed597b8f1743c1b2
+  config-opts:
+    - -Dexamples=disabled
+    - -Daom=disabled
+    - -Davtp=disabled
+    - -Dbs2b=disabled
+    - -Dchromaprint=disabled
+    - -Dcolormanagement=disabled
+    - -Dcuda=disabled
+    - -Dcurl-ssh2=disabled
+    - -Dcurl=disabled
+    - -Dd3dvideosink=disabled
+    - -Ddash=disabled
+    - -Ddc1394=disabled
+    - -Ddecklink=disabled
+    - -Ddirectfb=disabled
+    - -Ddirectsound=disabled
+    - -Ddoc=disabled
+    - -Ddtls=disabled
+    - -Ddts=disabled
+    - -Dfaac=disabled
+    - -Dfbdev=disabled
+    - -Dfestival=disabled
+    - -Dflite=disabled
+    - -Dfluidsynth=disabled
+    - -Dgme=disabled
+    - -Dgsm=disabled
+    - -Diqa=disabled
+    - -Dladspa=disabled
+    - -Dlibde265=disabled
+    - -Dlibmms=disabled
+    - -Dlv2=disabled
+    - -Dmagicleap=disabled
+    - -Dmicrodns=disabled
+    - -Dmodplug=disabled
+    - -Dmpeg2enc=disabled
+    - -Dmplex=disabled
+    - -Dmsdk=disabled
+    - -Dmusepack=disabled
+    - -Dneon=disabled
+    - -Dnvcodec=disabled
+    - -Dnvdec=disabled
+    - -Dnvenc=disabled
+    - -Dofa=disabled
+    - -Dopenal=disabled
+    - -Dopencv=disabled
+    - -Dopenexr=disabled
+    - -Dopenh264=disabled
+    - -Dopenmpt=disabled
+    - -Dopenni2=disabled
+    - -Dopensles=disabled
+    - -Dresindvd=disabled
+    - -Drsvg=disabled
+    - -Drtmp=disabled
+    - -Drtp=disabled
+    - -Dsbc=disabled
+    - -Dsctp=disabled
+    - -Dsndfile=disabled
+    - -Dsoundtouch=disabled
+    - -Dspandsp=disabled
+    - -Dsrt=disabled
+    - -Dsvthevcenc=disabled
+    - -Dteletext=disabled
+    - -Dtinyalsa=disabled
+    - -Dva=disabled
+    - -Dvaacenc=disabled
+    - -Dvdpau=disabled
+    - -Dvoaacenc=disabled
+    - -Dvoamrwbenc=disabled
+    - -Dvulkan=disabled
+    - -Dwasapi=disabled
+    - -Dwasapi2=disabled
+    - -Dwebp=disabled
+    - -Dwebrtcdsp=disabled
+    - -Dwebrtc=disabled
+    - -Dwildmidi=disabled
+    - -Dwinks=disabled
+    - -Dwinscreencap=disabled
+    - -Dwpe=disabled
+    - -Dzbar=disabled
+    - -Dzxing=disabled
+
+- name: ffmpeg
+  builddir: true
+  sources:
+    - type: git
+      url: https://git.ffmpeg.org/ffmpeg.git
+      tag: n4.3.1
+      commit: 6b6b9e593dd4d3aaf75f48d40a13ef03bdef9fdb
+  config-opts:
+    - --prefix="/app/"
+    - --libdir="/app/lib"
+    - --disable-doc
+    - --disable-static
+    - --enable-optimizations
+    - --enable-shared
+    - --disable-everything
+    - --disable-ffplay
+    - --disable-ffprobe
+    - --enable-gnutls
+    - --enable-libaom
+    - --enable-libdav1d
+    - --enable-libfdk-aac
+    - --enable-libmp3lame
+    - --enable-libfontconfig
+    - --enable-libfreetype
+    - --enable-libopenh264
+    - --enable-libopus
+    - --enable-libpulse
+    - --enable-libspeex
+    - --enable-libtheora
+    - --enable-libvorbis
+    - --enable-libvpx
+    - --enable-libwebp
+    - --enable-openal
+    - --enable-opengl
+    - --enable-sdl2
+    - --enable-decoder=ac3,alac,flac,g723_1,g729,libfdk_aac,libopus,mp2,mp3,m4a,pcm_alaw,pcm_mulaw,pcm_f32le,pcm_s16be,pcm_s24be,pcm_s16le,pcm_s24le,pcm_s32le,pcm_u8,tta,vorbis,wavpack
+    - --enable-decoder=ass,ffv1,libaom_av1,libdav1d,libopenh264,libvpx_vp8,libvpx_vp9,rawvideo,theora,vp8,vp9,flv,hevc,h263,h264,mpeg2video,mpeg4,msmpeg4,msmpeg4v1,msmpeg4v2,msmpeg4v3,vp6,vp6a,vp6f
+    - --enable-decoder=gif,png,tiff,webp
+    - --enable-parser=aac,ac3,flac,mpegaudio,mpeg4video,opus,vp3,vp8,vorbis,hevc,h264
+    - --enable-demuxer=aac,ac3,ass,flac,gif,matroska,mov,mp3,mpegvideo,ogg,wav
+    - --enable-filter=crop,scale
+    - --enable-protocol=file 
+
+- name: gst-libav
+  builddir: true
+  buildsystem: meson
+  sources:
+  - type: archive
+    url: https://gstreamer.freedesktop.org/src/gst-libav/gst-libav-1.18.1.tar.xz
+    sha256: 39a717bc2613efbbba19df3cf5cacff0987471fc8281ba2c5dcdeaded79c2ed8
+  config-opts:
+  - -Ddoc=disabled
+
 - name: gstreamer-vaapi
   buildsystem: meson
   builddir: true
-  config-opts:
-  - -Ddisable_gtkdoc=true
-  - --libdir=lib
   sources:
   - type: archive
-    url: https://gstreamer.freedesktop.org/src/gstreamer-vaapi/gstreamer-vaapi-1.16.2.tar.xz
-    sha256: 191de7b0ab64a85dd0875c990721e7be95518f60e2a9106beca162004ed7c601
+    url: https://gstreamer.freedesktop.org/src/gstreamer-vaapi/gstreamer-vaapi-1.18.1.tar.xz
+    sha256: 400d3c42810b50b4566df03f37319a6bdd758f969560c40147e7d9a3b0e8a6ea
+  config-opts:
+  - -Ddoc=disabled
+
 - name: glide
   buildsystem: meson
   sources:


### PR DESCRIPTION
GStreamer-vaapi 1.18 should work better with the iHD driver. Also include ffmpeg
with H.264 decoding support, which can be useful when vaapi is not usable.