### PR TITLE
Switch to GNOME 40 runtime

### DIFF
--- a/net.baseart.Glide.yaml
+++ b/net.baseart.Glide.yaml
@@ -1,6 +1,6 @@
 app-id: net.baseart.Glide
 runtime: org.gnome.Platform
-runtime-version: '3.38'
+runtime-version: '40'
 sdk: org.gnome.Sdk
 sdk-extensions:
 - org.freedesktop.Sdk.Extension.rust-stable


### PR DESCRIPTION
3.38 is EOL.